### PR TITLE
fix: remove main branch from SonarCloud push triggers

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,9 +2,10 @@ name: SonarCloud Analysis
 
 on:
   push:
-    branches: [main, develop]  # Only analyze default branches (free tier limitation)
+    branches: [develop]  # Only analyze develop branch (free tier limitation)
   pull_request:
     types: [opened, synchronize, reopened]
+    branches: [main, develop]  # Analyze PRs to main or develop
 
 jobs:
   sonarcloud:


### PR DESCRIPTION
### **User description**
SonarCloud free tier only analyzes PRs, not main branch pushes.
Updated workflow to only analyze develop pushes and PRs to main/develop.

This prevents SonarCloud failures when merging to main.


___

### **PR Type**
Bug fix


___

### **Description**
- Remove main branch from SonarCloud push triggers

- Add branch specification for pull request analysis

- Fix SonarCloud free tier compatibility issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Push to develop"] --> B["SonarCloud Analysis"]
  C["PR to main/develop"] --> B
  D["Push to main"] -.-> E["No Analysis (Removed)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sonarcloud.yml</strong><dd><code>Update SonarCloud trigger configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/sonarcloud.yml

<ul><li>Remove <code>main</code> branch from push triggers<br> <li> Add explicit branch targeting for pull requests<br> <li> Update comments to reflect free tier limitations</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/figure-collector-frontend/pull/21/files#diff-5895707186d21bd3672c2faf7743c1cd2d656de088cdec80dc676ed8e3f22bce">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

