### PR TITLE
Configure Dependabot to ignore problematic major version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,22 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
+    ignore:
+      # Ignore major version updates for packages with breaking changes or upstream blockers
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-router-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/jest"
+        update-types: ["version-update:semver-major"]
     groups:
       # Group all patch updates (0.0.x) - non-breaking by semver
       patch-updates:


### PR DESCRIPTION
### **User description**
## Summary
Configures Dependabot to ignore major version updates for packages that have breaking changes or upstream dependency blockers.

## Changes
Added ignore rules to `.github/dependabot.yml` for:
- **react/react-dom**: Major updates (e.g., React 19) require coordinated migration effort across the codebase
- **@types/react/@types/react-dom**: Must match corresponding React versions  
- **react-router-dom**: v7 is a major rewrite with breaking API changes requiring code updates
- **typescript**: react-scripts@5.x doesn't support TypeScript 5 yet (requires ^3.2.1 || ^4)
- **@types/jest**: @emotion/jest@11.13.0 doesn't support v30 yet (requires ^26 || ^27 || ^28 || ^29)

## Related PRs Closed
- Closed #35 - React 19 upgrade (version mismatch)
- Closed #38 - TypeScript 5 upgrade (react-scripts incompatibility)
- Closed #39 - @types/jest v30 upgrade (@emotion/jest incompatibility)
- Closed #48 - React Router v7 upgrade (breaking changes)

## Impact
- Dependabot will continue to create PRs for **minor and patch updates** of these packages
- **Major version updates** will be handled manually when we're ready for migration
- Prevents problematic automated PRs that can't be merged

## Test Plan
- [x] Verified dependabot.yml syntax
- [x] Confirmed all closed PRs had legitimate blocking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Configure Dependabot to ignore major version updates for problematic packages

- Prevents automated PRs for react, react-dom, react-router-dom, typescript, and type packages

- Allows minor and patch updates to continue automatically

- Addresses breaking changes and upstream dependency incompatibilities


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dependabot Configuration"] -->|Add ignore rules| B["Major Version Updates"]
  B -->|Block| C["react/react-dom"]
  B -->|Block| D["@types/react/@types/react-dom"]
  B -->|Block| E["react-router-dom"]
  B -->|Block| F["typescript"]
  B -->|Block| G["@types/jest"]
  H["Minor/Patch Updates"] -->|Continue| I["Automatic Updates"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Add major version ignore rules for npm packages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Added <code>ignore</code> section to npm package ecosystem configuration<br> <li> Configured 7 packages to ignore major version updates (react, <br>react-dom, @types/react, @types/react-dom, react-router-dom, <br>typescript, @types/jest)<br> <li> Each package specifies <code>version-update:semver-major</code> as the update type <br>to ignore<br> <li> Minor and patch updates remain unaffected and will continue to be <br>processed</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/figure-collector-frontend/pull/49/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

