### PR TITLE
fix: Correct Docker workflow tag trigger configuration

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,11 +4,11 @@ on:
   # Automatic triggers
   push:
     branches: [develop, main]
+    tags:
+      - 'v*.*.*'  # Semantic version tags like v1.0.0, v1.0.0-application
   pull_request:
     branches: [develop, main]
     types: [opened, synchronize, reopened]
-    tags:
-      - 'v*.*.*'  # Semantic version tags like v1.0.0
 
   # Manual trigger from GitHub Actions UI
   workflow_dispatch:


### PR DESCRIPTION
### **User description**
Moves tags trigger from pull_request to push section.


___

### **PR Type**
Bug fix


___

### **Description**
- Move tags trigger from pull_request to push section

- Ensure Docker images build only on version tag pushes

- Fix workflow configuration for proper CI/CD execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["docker-publish.yml"] -- "Move tags trigger" --> B["push section"]
  C["pull_request section"] -- "Remove tags" --> D["Cleanup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Relocate semantic version tags to push trigger</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<ul><li>Relocated tags trigger pattern from <code>pull_request</code> to <code>push</code> section<br> <li> Tags now only trigger builds on push events with semantic version <br>pattern <code>v*.*.*</code><br> <li> Removed duplicate tags configuration from pull_request workflow <br>trigger<br> <li> Maintains existing pull_request trigger for opened, synchronize, <br>reopened events</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/figure-collector-frontend/pull/59/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

