### PR TITLE
Fix markdown styling for dark mode

### DIFF
--- a/src/components/FigureForm.tsx
+++ b/src/components/FigureForm.tsx
@@ -76,6 +76,8 @@ const FigureForm: React.FC<FigureFormProps> = ({ initialData, onSubmit, isLoadin
 
   const previewBorderColor = useColorModeValue('gray.200', 'gray.600');
   const previewBg = useColorModeValue('gray.50', 'gray.700');
+  const codeBg = useColorModeValue('gray.100', 'gray.700');
+  const linkColor = useColorModeValue('blue.500', 'blue.300');
 
   const {
     register,
@@ -602,10 +604,12 @@ const FigureForm: React.FC<FigureFormProps> = ({ initialData, onSubmit, isLoadin
                       '& p': { mb: 2 },
                       '& ul, & ol': { pl: 4, mb: 2 },
                       '& li': { mb: 1 },
-                      '& code': { bg: 'gray.100', px: 1, borderRadius: 'sm', fontSize: 'xs' },
-                      '& pre': { bg: 'gray.100', p: 2, borderRadius: 'md', overflowX: 'auto', fontSize: 'xs' },
-                      '& a': { color: 'blue.500', textDecoration: 'underline' },
+                      '& code': { bg: codeBg, px: 1, borderRadius: 'sm', fontSize: 'xs' },
+                      '& pre': { bg: codeBg, p: 2, borderRadius: 'md', overflowX: 'auto', fontSize: 'xs' },
+                      '& a': { color: linkColor, textDecoration: 'underline' },
                       '& strong': { fontWeight: 'bold' },
+                      '& table': { width: '100%', mb: 2 },
+                      '& th, & td': { border: '1px solid', borderColor: 'gray.300', p: 2, textAlign: 'left' },
                     }}>
                       {mfcConfigs.mfc_cookie_instructions?.value && (
                         <Markdown>{mfcConfigs.mfc_cookie_instructions.value}</Markdown>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -60,6 +60,8 @@ const Profile: React.FC = () => {
   const helpBg = useColorModeValue('gray.50', 'gray.800');
   const storageTextColor = useColorModeValue('blue.600', 'blue.300');
   const warningColor = useColorModeValue('red.600', 'red.400');
+  const codeBg = useColorModeValue('gray.100', 'gray.700');
+  const linkColor = useColorModeValue('blue.500', 'blue.300');
 
   const { user, setUser, logout } = useAuthStore();
   const navigate = useNavigate();
@@ -430,10 +432,12 @@ const Profile: React.FC = () => {
                     '& p': { mb: 2 },
                     '& ul, & ol': { pl: 4, mb: 2 },
                     '& li': { mb: 1 },
-                    '& code': { bg: 'gray.100', px: 1, borderRadius: 'sm', fontSize: 'xs' },
-                    '& pre': { bg: 'gray.100', p: 2, borderRadius: 'md', overflowX: 'auto', fontSize: 'xs' },
-                    '& a': { color: 'blue.500', textDecoration: 'underline' },
+                    '& code': { bg: codeBg, px: 1, borderRadius: 'sm', fontSize: 'xs' },
+                    '& pre': { bg: codeBg, p: 2, borderRadius: 'md', overflowX: 'auto', fontSize: 'xs' },
+                    '& a': { color: linkColor, textDecoration: 'underline' },
                     '& strong': { fontWeight: 'bold' },
+                    '& table': { width: '100%', mb: 2 },
+                    '& th, & td': { border: '1px solid', borderColor: 'gray.300', p: 2, textAlign: 'left' },
                   }}>
                     {mfcConfigs.mfc_cookie_instructions?.value && (
                       <Markdown>{mfcConfigs.mfc_cookie_instructions.value}</Markdown>


### PR DESCRIPTION
### **User description**
## Summary
- Use color mode aware values for code/pre backgrounds
- Use color mode aware link colors
- Add table styling for markdown tables

## Test plan
- [x] All 445 tests pass
- [x] Verified dark mode renders correctly


___

### **PR Type**
Enhancement


___

### **Description**
- Add dark mode support for markdown code and link styling

- Introduce color mode aware variables for code backgrounds

- Add table styling for markdown rendered content

- Apply consistent styling across FigureForm and Profile components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useColorModeValue hooks"] -->|codeBg| B["Code/Pre elements"]
  A -->|linkColor| C["Link elements"]
  D["Table styling rules"] -->|width & borders| E["Markdown tables"]
  B --> F["FigureForm & Profile"]
  C --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FigureForm.tsx</strong><dd><code>Dark mode markdown styling in FigureForm</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/FigureForm.tsx

<ul><li>Add <code>codeBg</code> and <code>linkColor</code> color mode aware variables using <br><code>useColorModeValue</code><br> <li> Replace hardcoded <code>gray.100</code> with <code>codeBg</code> variable for code and pre <br>elements<br> <li> Replace hardcoded <code>blue.500</code> with <code>linkColor</code> variable for anchor elements<br> <li> Add table styling rules for width, borders, padding and text alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/fc-frontend/pull/94/files#diff-6799ba857e699c29556bb5d39c6868d156253f1d62fd7ddbed4709b0930a8095">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Profile.tsx</strong><dd><code>Dark mode markdown styling in Profile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/pages/Profile.tsx

<ul><li>Add <code>codeBg</code> and <code>linkColor</code> color mode aware variables using <br><code>useColorModeValue</code><br> <li> Replace hardcoded <code>gray.100</code> with <code>codeBg</code> variable for code and pre <br>elements<br> <li> Replace hardcoded <code>blue.500</code> with <code>linkColor</code> variable for anchor elements<br> <li> Add table styling rules for width, borders, padding and text alignment</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/fc-frontend/pull/94/files#diff-1ff08a1cfd3c51dd1c17db9089fbf4e3f52862e57e50943f1d6cea2a98405d09">+7/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

