### PR TITLE
Fix container security alerts (Trivy)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 # Multi-stage Dockerfile for Figure Collector Frontend
 # Supports: base, development, test, builder, production stages
-# Security patch: CVE-2025-9900 (libtiff) via Ubuntu 22.04 latest packages
 
 # ============================================================================
-# BASE STAGE - Ubuntu 22.04 with Node.js and security patches
+# BASE STAGE - Ubuntu 24.04 with Node.js and security patches
 # ============================================================================
 FROM ubuntu:24.04 as base
 
-# Update all packages including libtiff5 security patch (CVE-2025-9900)
-# Target: libtiff5 4.3.0-6ubuntu0.11 → 4.3.0-6ubuntu0.12
+# Cache-bust ARG to invalidate Docker layers when security patches are needed
+ARG CACHE_BUST=2026-02-12-npm-11.10-openssl-glibc-patches
+
+# Update all packages for latest security patches (openssl, glibc, gnupg)
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y \
     curl \
@@ -108,6 +109,9 @@ RUN npm run build
 # ============================================================================
 FROM ubuntu:24.04 as production
 
+# Cache-bust ARG for production stage security patches
+ARG CACHE_BUST=2026-02-12-npm-11.10-openssl-glibc-patches
+
 # Build arguments for OCI labels
 ARG GITHUB_ORG=rpgoldberg
 ARG GITHUB_REPO=fc-frontend
@@ -118,7 +122,7 @@ LABEL org.opencontainers.image.description="React frontend for Figure Collector"
 LABEL org.opencontainers.image.vendor="Figure Collector Services"
 LABEL org.opencontainers.image.source="https://github.com/${GITHUB_ORG}/${GITHUB_REPO}"
 
-# Update all packages including libtiff5 security patch (CVE-2025-9900)
+# Update all packages for latest security patches (openssl, glibc, gnupg)
 RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y \
     nginx \


### PR DESCRIPTION
### **User description**
## Summary
- Add Dockerfile CACHE_BUST to force fresh apt-get/npm upgrades resolving:
  - OpenSSL CVEs (CVE-2025-15467, CVE-2025-69419, CVE-2025-69421, etc.)
  - glibc CVEs (CVE-2026-0915, CVE-2026-0861, CVE-2025-15281)
  - GnuPG CVE (CVE-2025-68973)
  - npm bundled tar CVEs (CVE-2026-24842, CVE-2026-23950, CVE-2026-23745)
  - npm bundled glob CVE (CVE-2025-64756)

## Test plan
- [x] All 1024 frontend tests pass
- [ ] Trivy container scan passes in CI


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add CACHE_BUST ARG to force fresh package upgrades in Docker builds

- Resolves multiple CVEs in OpenSSL, glibc, GnuPG, and npm dependencies

- Update base image documentation from Ubuntu 22.04 to 24.04

- Improve security patch comments for clarity and maintainability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dockerfile"] -->|Add CACHE_BUST ARG| B["Force layer invalidation"]
  B -->|Trigger fresh apt-get| C["Latest security patches"]
  C -->|Resolve CVEs| D["OpenSSL, glibc, GnuPG, npm"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add cache-bust ARG for security patch updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Dockerfile

<ul><li>Add <code>CACHE_BUST</code> ARG with timestamp to base and production stages to <br>invalidate Docker cache layers<br> <li> Update security patch comments to reference OpenSSL, glibc, and GnuPG <br>instead of specific CVE numbers<br> <li> Correct base image documentation from Ubuntu 22.04 to Ubuntu 24.04<br> <li> Ensure consistent cache-busting across both base and production build <br>stages</ul>


</details>


  </td>
  <td><a href="https://github.com/rpgoldberg/fc-frontend/pull/139/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

