### PR TITLE
Merge back v3.1.2 release to develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fc-frontend",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fc-frontend",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "dependencies": {
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.10.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fc-frontend",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "private": true,
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",


### PR DESCRIPTION
Merge the v3.1.2 release (version bump) back to develop to keep branches in sync.