### PR TITLE
Disable tags population from MFC scraper results

### DIFF
--- a/src/components/FigureForm/FigureFormMain.tsx
+++ b/src/components/FigureForm/FigureFormMain.tsx
@@ -449,10 +449,11 @@ const FigureForm: React.FC<FigureFormProps> = ({ initialData, onSubmit, isLoadin
             setValue('materials', result.data.materials, { shouldValidate: true, shouldDirty: true });
             fieldsPopulated++;
           }
-          if ((!currentValues.tags || currentValues.tags.length === 0) && result.data.tags && result.data.tags.length > 0) {
-            setValue('tags', result.data.tags, { shouldValidate: true, shouldDirty: true });
-            fieldsPopulated++;
-          }
+          // Tags field disabled — MFC extraction needs refinement (future release)
+          // if ((!currentValues.tags || currentValues.tags.length === 0) && result.data.tags && result.data.tags.length > 0) {
+          //   setValue('tags', result.data.tags, { shouldValidate: true, shouldDirty: true });
+          //   fieldsPopulated++;
+          // }
 
           // Schema v3: Populate company roles from scraped data
           if (result.data.companies && result.data.companies.length > 0) {


### PR DESCRIPTION
## Summary
- Disables populating tags field from MFC scraper results in the Add/Edit Figure form
- MFC tag extraction needs refinement before use (warning notices being captured as tags)
- Tags feature will be revisited in a future release

## Test plan
- [x] Frontend builds successfully with CI=true
- [x] No ESLint errors
- [x] Figure form still populates all other MFC fields correctly