### PR TITLE
Release 3.2.3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 FigureCollecting
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -7,6 +7,9 @@ server {
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
+
+    # Prevent internal port from leaking into redirects (e.g. /login → /login/)
+    absolute_redirect off;
     
     access_log off;
     

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fc-frontend",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "private": true,
   "dependencies": {
     "@chakra-ui/icons": "^2.2.4",


### PR DESCRIPTION
## Summary
- Fix nginx `absolute_redirect` causing 301 redirects to leak internal container port (e.g. `/login` → `http://figurecollecting.com:5051/login/`), which broke Google Search Console indexing
- Add MIT license

## Test plan
- [x] All 1105 tests pass, zero regression
- [ ] After deploy, verify `curl -sI https://figurecollecting.com/login` returns relative redirect `/login/` instead of absolute with port 5051
- [ ] Google Search Console can successfully fetch and index `/login`