### PR TITLE
Bump react-helmet-async 3 (non-breaking); react-icons 5 blocked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "framer-motion": "^12.40.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-helmet-async": "^2.0.5",
+        "react-helmet-async": "^3.0.0",
         "react-hook-form": "^7.65.0",
         "react-icons": "^4.11.0",
         "react-markdown": "^10.1.0",
@@ -22474,9 +22474,9 @@
       }
     },
     "node_modules/react-helmet-async": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
-      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-3.0.0.tgz",
+      "integrity": "sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==",
       "license": "Apache-2.0",
       "dependencies": {
         "invariant": "^2.2.4",
@@ -22484,7 +22484,7 @@
         "shallowequal": "^1.1.0"
       },
       "peerDependencies": {
-        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "framer-motion": "^12.40.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-helmet-async": "^2.0.5",
+    "react-helmet-async": "^3.0.0",
     "react-hook-form": "^7.65.0",
     "react-icons": "^4.11.0",
     "react-markdown": "^10.1.0",


### PR DESCRIPTION
## Summary

Bumps `react-helmet-async` v2 -> **3.0.0** (major). Same `Helmet`/`HelmetProvider` API; all 6 usage files unchanged (zero code changes).

**`react-icons` v5 is intentionally NOT included** — it breaks the build (details below). This PR ships only the verified-clean half.

## Verification (react-helmet-async 3.0.0 + react-icons 4.12.0)
- Build: `CI=true npm run build` -> **Compiled successfully** (type-check + production build green)
- Tests: `CI=true npm test -- --watchAll=false` -> **1105 passed / 1105**, 67/67 suites
- Prod audit (`npm audit --omit=dev`): **0 high / 0 critical**; 2 moderate (`brace-expansion`, `yaml`) are **pre-existing** (identical on upstream/develop baseline), unrelated to this bump
- Resolved version: `npm ls react-helmet-async` -> `react-helmet-async@3.0.0`

## react-icons v5 blocked (do not merge that bump yet)
react-icons v5 changed `IconType` from `(props) => JSX.Element` to `(props) => React.ReactNode`. Under this project's CRA/ForkTsChecker + Chakra UI + TS 4.9.5 + @types/react 18.3.x stack, that type no longer satisfies Chakra's `as` prop, so every `<Icon as={FaX} />` / `<AlertIcon as={...} />` call site fails the build:

```
TS2322: Type 'IconType' is not assignable to type 'ElementType<any, keyof IntrinsicElements> | undefined'.
  src/components/BulkImportModal.tsx:302  <AlertIcon as={... ? FaExclamationTriangle : FaCheckCircle} />
```

Baseline (react-icons v4) compiles cleanly, confirming this is a v5 regression for our stack — not pre-existing. A fix would require either touching 30+ icon call sites or a non-trivial type/tooling change (TS / @types upgrade), neither of which is a safe minimal bump. Keeping Dependabot #168 open until that work is scoped.

## Supersedes
- Supersedes #170 (react-helmet-async)
- Does NOT supersede #168 (react-icons) — keep open, blocked as described above
