### PR TITLE
FE-4: migrate to react-router 7.18.3; drop react-router-dom and future flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react-icons": "^5.7.0",
         "react-markdown": "^10.1.0",
         "react-query": "^3.39.3",
-        "react-router-dom": "^6.30.6",
+        "react-router": "^7.18.3",
         "web-vitals": "^5.1.0",
         "zustand": "^5.0.15"
       },
@@ -3605,15 +3605,6 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
-      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm-eabi": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.6.tgz",
@@ -6271,6 +6262,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
@@ -10541,35 +10545,25 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
-      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.3.tgz",
+      "integrity": "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
-      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@remix-run/router": "1.23.4",
-        "react-router": "6.30.6"
+        "react": ">=18",
+        "react-dom": ">=18"
       },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/redent": {
@@ -10832,6 +10826,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "react-icons": "^5.7.0",
     "react-markdown": "^10.1.0",
     "react-query": "^3.39.3",
-    "react-router-dom": "^6.30.6",
+    "react-router": "^7.18.3",
     "web-vitals": "^5.1.0",
     "zustand": "^5.0.15"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate } from 'react-router';
 import { Box } from '@chakra-ui/react';
 import { useAuthStore } from './stores/authStore';
 import Layout from './components/Layout';

--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -89,7 +89,7 @@ jest.mock('../pages/NotFound', () => {
 
 jest.mock('../components/Layout', () => {
   return function MockLayout() {
-    const { Outlet } = require('react-router-dom');
+    const { Outlet } = require('react-router');
     return (
       <div data-testid="layout">
         <div data-testid="layout-header">Layout Header</div>

--- a/src/__tests__/ListDetail.test.tsx
+++ b/src/__tests__/ListDetail.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ChakraProvider } from '@chakra-ui/react';
 import ListDetail from '../pages/ListDetail';
@@ -15,8 +15,8 @@ const mockUpdateList = api.updateList as jest.MockedFunction<typeof api.updateLi
 
 // Mock useNavigate
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
 }));
 
@@ -81,7 +81,7 @@ function renderListDetail(listId = 'list1') {
   const result = render(
     <QueryClientProvider client={queryClient}>
       <ChakraProvider value={system}>
-        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }} initialEntries={[`/lists/${listId}`]}>
+        <MemoryRouter initialEntries={[`/lists/${listId}`]}>
           <Routes>
             <Route path="/lists/:id" element={<ListDetail />} />
           </Routes>

--- a/src/__tests__/Lists.test.tsx
+++ b/src/__tests__/Lists.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ChakraProvider } from '@chakra-ui/react';
 import Lists from '../pages/Lists';
@@ -16,8 +16,8 @@ const mockCreateList = api.createList as jest.MockedFunction<typeof api.createLi
 
 // Mock useNavigate
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
 }));
 
@@ -113,7 +113,7 @@ function renderLists() {
   const result = render(
     <QueryClientProvider client={queryClient}>
       <ChakraProvider value={system}>
-        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <MemoryRouter>
           <Lists />
         </MemoryRouter>
       </ChakraProvider>

--- a/src/__tests__/Statistics.test.tsx
+++ b/src/__tests__/Statistics.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ChakraProvider } from '@chakra-ui/react';
 import Statistics from '../pages/Statistics';
@@ -14,8 +14,8 @@ const mockGetFigureStats = api.getFigureStats as jest.MockedFunction<typeof api.
 
 // Mock useNavigate
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
 }));
 
@@ -119,7 +119,7 @@ function renderStatistics() {
   const result = render(
     <QueryClientProvider client={queryClient}>
       <ChakraProvider value={system}>
-        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <MemoryRouter>
           <Statistics />
         </MemoryRouter>
       </ChakraProvider>

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useColorModeValue } from "./ui/color-mode";
 import { Box, Text, Button, VStack, Icon } from '@chakra-ui/react';
 import { FaPlus, FaCube, FaSearch, FaTimes, FaFilter } from 'react-icons/fa';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { redirectTo } from '../utils/navigation';
 
 interface EmptyStateProps {

--- a/src/components/FigureCard.tsx
+++ b/src/components/FigureCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useColorModeValue } from "./ui/color-mode";
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { Box, Image, Text, Badge, Link, Flex, IconButton, HStack } from '@chakra-ui/react';
 import { toaster } from './ui/toaster';
 import { FaEdit, FaTrash } from 'react-icons/fa';

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useColorModeValue } from "./ui/color-mode";
-import { Outlet } from 'react-router-dom';
+import { Outlet } from 'react-router';
 import { Box,
   Container,
   Text,

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useColorModeValue } from "./ui/color-mode";
-import { Link as RouterLink, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router';
 import {
   Box,
   Flex,

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useColorModeValue } from "./ui/color-mode";
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   InputGroup,
   Input,

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link as RouterLink, useLocation } from 'react-router-dom';
+import { Link as RouterLink, useLocation } from 'react-router';
 import { Box, Stack, Link, Text, Icon, Flex } from '@chakra-ui/react';
 import { FaHome, FaCube, FaPlus, FaSearch, FaChartBar, FaListUl, FaUser } from 'react-icons/fa';
 

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -3,7 +3,7 @@
  */
 import React from 'react';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { ChakraProvider } from '@chakra-ui/react';
 import { ColorModeProvider } from '../ui/color-mode';
 import system from '../../theme';
@@ -28,9 +28,9 @@ jest.mock('../Sidebar', () => {
   };
 });
 
-// Mock Outlet from react-router-dom
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+// Mock Outlet from react-router
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   Outlet: () => <div data-testid="mock-outlet">Page Content</div>,
 }));
 
@@ -41,7 +41,7 @@ const renderLayout = () => {
   return render(
     <ChakraProvider value={system}>
       <ColorModeProvider>
-        <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+        <BrowserRouter>
           <Layout />
         </BrowserRouter>
       </ColorModeProvider>

--- a/src/components/__tests__/Navbar.test.tsx
+++ b/src/components/__tests__/Navbar.test.tsx
@@ -5,10 +5,10 @@ import { render, mockUser } from '../../test-utils';
 import Navbar from '../Navbar';
 import { useAuthStore } from '../../stores/authStore';
 
-// Mock react-router-dom
+// Mock react-router
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
 }));
 

--- a/src/components/__tests__/SearchBar.test.tsx
+++ b/src/components/__tests__/SearchBar.test.tsx
@@ -17,8 +17,8 @@ jest.mock('react-query', () => ({
 }));
 
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
 }));
 

--- a/src/components/__tests__/Sidebar.test.tsx
+++ b/src/components/__tests__/Sidebar.test.tsx
@@ -3,10 +3,10 @@ import { screen } from '@testing-library/react';
 import { render } from '../../test-utils';
 import Sidebar from '../Sidebar';
 
-// Mock react-router-dom to control location
+// Mock react-router to control location
 const mockUseLocation = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useLocation: () => mockUseLocation(),
 }));
 

--- a/src/hooks/__tests__/useFigureListState.test.ts
+++ b/src/hooks/__tests__/useFigureListState.test.ts
@@ -3,13 +3,13 @@
  */
 import { renderHook, act } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { useFigureListState, EMPTY_FACETED_FILTERS } from '../useFigureListState';
 
 // Wrapper that provides router context
 function createWrapper(initialEntries: string[] = ['/']) {
   return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(MemoryRouter, { initialEntries, future: { v7_startTransition: true, v7_relativeSplatPath: true } }, children);
+    React.createElement(MemoryRouter, { initialEntries }, children);
 }
 
 describe('useFigureListState', () => {

--- a/src/hooks/useFigureListState.ts
+++ b/src/hooks/useFigureListState.ts
@@ -24,7 +24,7 @@
  */
 
 import { useCallback, useMemo } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { CollectionStatus } from '../types';
 import { FacetedFilters } from '../components/FacetedFilterSidebar';
 import { PageSizeValue, DEFAULT_PAGE_SIZE, PAGE_SIZE_PRESETS, CardLayout, DEFAULT_CARD_LAYOUT } from '../components/Pagination';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { HelmetProvider } from 'react-helmet-async';
 import App from './App';
@@ -22,7 +22,7 @@ const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
     <HelmetProvider>
-      <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      <BrowserRouter>
         <QueryClientProvider client={queryClient}>
           <Provider defaultTheme="light">
             <App />

--- a/src/pages/AddFigure.tsx
+++ b/src/pages/AddFigure.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useRef } from 'react';
 import { useColorModeValue } from "../components/ui/color-mode";
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, Link as RouterLink } from 'react-router';
 import { useMutation, useQueryClient } from 'react-query';
 import { Box, Heading, Button, Flex, Breadcrumb, Icon } from '@chakra-ui/react';
 import { toaster } from '../components/ui/toaster';

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useColorModeValue } from "../components/ui/color-mode";
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { Box,
   Heading,
   SimpleGrid,
@@ -23,7 +23,7 @@ import { useQuery, useQueryClient } from 'react-query';
 import { getFigures, getFigureStats } from '../api';
 import FigureCard from '../components/FigureCard';
 import SearchBar from '../components/SearchBar';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { CollectionStatus } from '../types';
 
 const Dashboard: React.FC = () => {

--- a/src/pages/EditFigure.tsx
+++ b/src/pages/EditFigure.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useColorModeValue } from "../components/ui/color-mode";
-import { useParams, useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useParams, useNavigate, Link as RouterLink } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { Box,
   Heading,

--- a/src/pages/FigureDetail.tsx
+++ b/src/pages/FigureDetail.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useColorModeValue } from "../components/ui/color-mode";
-import { useParams, useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useParams, useNavigate, Link as RouterLink } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { Box,
   Heading,

--- a/src/pages/FigureList.tsx
+++ b/src/pages/FigureList.tsx
@@ -18,7 +18,7 @@ import { Box,
 } from '@chakra-ui/react';
 import { toaster } from '../components/ui/toaster';
 import { FaPlus, FaSync, FaChevronDown } from 'react-icons/fa';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { getFigures, filterFigures, getFigureStats } from '../api';
 import FigureCard from '../components/FigureCard';
 import { FacetedFilters } from '../components/FacetedFilterSidebar';

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { Box, Heading, Text, Input, Button, Alert, VStack, Link, Field } from '@chakra-ui/react';
 import { forgotPasswordRequest } from '../api';
 

--- a/src/pages/ListDetail.tsx
+++ b/src/pages/ListDetail.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import DOMPurify from 'dompurify';
 import { Box,
   Heading,

--- a/src/pages/Lists.tsx
+++ b/src/pages/Lists.tsx
@@ -15,7 +15,7 @@ import { Box,
 import { Tooltip } from '../components/ui/tooltip';
 import { toaster } from '../components/ui/toaster';
 import { FaTrash, FaChevronLeft, FaChevronRight, FaPlus } from 'react-icons/fa';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { getLists, deleteList, createList } from '../api';
 import { MfcList, MfcListFormData } from '../types';
 import ListFormModal from '../components/ListFormModal';

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useColorModeValue } from "../components/ui/color-mode";
 import { Helmet } from 'react-helmet-async';
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, Link as RouterLink } from 'react-router';
 import { useMutation } from 'react-query';
 import { Box,
   Button,

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link as RouterLink } from 'react-router-dom';
+import { Link as RouterLink } from 'react-router';
 import { Box, Heading, Text, Button, VStack, Icon } from '@chakra-ui/react';
 import { FaExclamationTriangle, FaHome } from 'react-icons/fa';
 

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useColorModeValue } from "../components/ui/color-mode";
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, Link as RouterLink } from 'react-router';
 import { useQuery, useMutation, useQueryClient } from 'react-query';
 import { Box,
   Heading,

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useColorModeValue } from "../components/ui/color-mode";
 import { Helmet } from 'react-helmet-async';
-import { useNavigate, Link as RouterLink } from 'react-router-dom';
+import { useNavigate, Link as RouterLink } from 'react-router';
 import { useMutation } from 'react-query';
 import { Box,
   Button,

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Helmet } from 'react-helmet-async';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router';
 import { Box, Heading, Input, Button, Alert, VStack, Text, Field } from '@chakra-ui/react';
 import { resetPasswordRequest } from '../api';
 

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router';
 import { useQuery } from 'react-query';
 import { Box, Heading, SimpleGrid, Spinner, Center, Text, Flex } from '@chakra-ui/react';
 import { toaster } from '../components/ui/toaster';

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { useColorModeValue } from "../components/ui/color-mode";
 import { useQuery } from 'react-query';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { Box,
   Heading,
   SimpleGrid,

--- a/src/pages/VerifyEmail.tsx
+++ b/src/pages/VerifyEmail.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router';
 import { Box, Heading, Spinner, Alert, Button, VStack } from '@chakra-ui/react';
 import { verifyEmailToken } from '../api';
 

--- a/src/pages/__tests__/AddFigure.test.tsx
+++ b/src/pages/__tests__/AddFigure.test.tsx
@@ -11,9 +11,9 @@ const mockUseAuthStore = useAuthStore as jest.MockedFunction<typeof useAuthStore
 // Mock navigate function
 const mockNavigate = jest.fn();
 
-// Mock react-router-dom
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+// Mock react-router
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
   Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,
 }));

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -39,10 +39,10 @@ jest.mock('../../components/SearchBar', () => {
   };
 });
 
-// Mock react-router-dom
+// Mock react-router
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => {
-  const actual = jest.requireActual('react-router-dom');
+jest.mock('react-router', () => {
+  const actual = jest.requireActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/src/pages/__tests__/EditFigure.test.tsx
+++ b/src/pages/__tests__/EditFigure.test.tsx
@@ -11,9 +11,9 @@ const mockUseAuthStore = useAuthStore as jest.MockedFunction<typeof useAuthStore
 // Mock navigate function
 const mockNavigate = jest.fn();
 
-// Mock react-router-dom
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+// Mock react-router
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
   useParams: () => ({ id: '123' }),
   Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,

--- a/src/pages/__tests__/FigureDetail.test.tsx
+++ b/src/pages/__tests__/FigureDetail.test.tsx
@@ -8,10 +8,10 @@ import { useAuthStore } from '../../stores/authStore';
 jest.mock('../../stores/authStore');
 const mockUseAuthStore = useAuthStore as jest.MockedFunction<typeof useAuthStore>;
 
-// Mock react-router-dom
+// Mock react-router
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
   useParams: () => ({ id: '123' }),
   Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,

--- a/src/pages/__tests__/FigureList.test.tsx
+++ b/src/pages/__tests__/FigureList.test.tsx
@@ -21,9 +21,9 @@ jest.mock('../../utils/navigation', () => ({
 }));
 import { reloadPage } from '../../utils/navigation';
 
-// Mock react-router-dom
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+// Mock react-router
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => jest.fn(),
   Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,
 }));

--- a/src/pages/__tests__/Login.test.tsx
+++ b/src/pages/__tests__/Login.test.tsx
@@ -9,10 +9,10 @@ import { useAuthStore } from '../../stores/authStore';
 jest.mock('../../stores/authStore');
 const mockUseAuthStore = useAuthStore as jest.MockedFunction<typeof useAuthStore>;
 
-// Mock react-router-dom
+// Mock react-router
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
   Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,
 }));

--- a/src/pages/__tests__/Profile.test.tsx
+++ b/src/pages/__tests__/Profile.test.tsx
@@ -19,8 +19,8 @@ jest.mock('../../stores/authStore');
 const mockUseAuthStore = useAuthStore as jest.MockedFunction<typeof useAuthStore>;
 
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
   Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,
 }));

--- a/src/pages/__tests__/Register.test.tsx
+++ b/src/pages/__tests__/Register.test.tsx
@@ -8,10 +8,10 @@ import { useAuthStore } from '../../stores/authStore';
 jest.mock('../../stores/authStore');
 const mockUseAuthStore = useAuthStore as jest.MockedFunction<typeof useAuthStore>;
 
-// Mock react-router-dom
+// Mock react-router
 const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useNavigate: () => mockNavigate,
   Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,
 }));

--- a/src/pages/__tests__/Search.test.tsx
+++ b/src/pages/__tests__/Search.test.tsx
@@ -8,9 +8,9 @@ import { useAuthStore } from '../../stores/authStore';
 jest.mock('../../stores/authStore');
 const mockUseAuthStore = useAuthStore as jest.MockedFunction<typeof useAuthStore>;
 
-// Mock react-router-dom
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
+// Mock react-router
+jest.mock('react-router', () => ({
+  ...jest.requireActual('react-router'),
   useSearchParams: () => [new URLSearchParams('q=test'), jest.fn()],
   useNavigate: () => jest.fn(),
   Link: ({ children, to, ...props }: any) => <a href={to} {...props}>{children}</a>,

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -4,6 +4,17 @@
  * All library-specific mocks are in src/test-utils/mocks/
  */
 
+// Node globals react-router v7 needs under jsdom (not provided by jest-environment-jsdom)
+import { TextDecoder, TextEncoder } from 'node:util';
+import { ReadableStream, TransformStream, WritableStream } from 'node:stream/web';
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  Object.assign(globalThis, { TextEncoder, TextDecoder });
+}
+if (typeof globalThis.ReadableStream === 'undefined') {
+  Object.assign(globalThis, { ReadableStream, WritableStream, TransformStream });
+}
+
 import '@testing-library/jest-dom';
 import 'jest-axe/extend-expect';
 import { configure } from '@testing-library/react';

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement } from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { ChakraProvider } from '@chakra-ui/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { CacheProvider } from '@emotion/react';
 import createCache from '@emotion/cache';
 import { HelmetProvider } from 'react-helmet-async';
@@ -45,7 +45,7 @@ const AllProviders = ({ children, initialRoutes = ['/'] }: {
         <MockQueryClientProvider>
           <ChakraProvider value={system}>
             <ColorModeProvider>
-              <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }} initialEntries={initialRoutes}>
+              <MemoryRouter initialEntries={initialRoutes}>
                 {children}
               </MemoryRouter>
             </ColorModeProvider>


### PR DESCRIPTION
## FE-4: react-router 6 → 7 (final unit of the 2026-09 sweep)

One commit; adversarially reviewed with mutation testing against the **real** v7 router and a **byte-compare of prerendered route HTML** between v6-baseline and v7 builds (identical after asset-hash normalization — zero routing-output drift).

- **`react-router-dom` removed entirely** → `react-router ^7.18.3` (the guide's prescribed swap; v7 collapsed the dom package into core). 32 imports + 16 jest.mock sites rewritten; zero dom-package residue (grep-proven, lock included).
- **`future={...}` props removed from all 7 sites** — v7 types have no `future` member (excess-prop error); FE-2 had already proven both flags no-op, making this swap mechanical by design.
- **jsdom polyfills** (+11 guarded lines in setupTests): react-router 7 requires TextEncoder/web-streams at import — proven red first (37 suites failing with exactly that error), then green.
- Data-router breaks all n-a (declarative-only app, grep-proven).

### Gates (three independent runs)
**69/69 suites, 1106/1106 tests** — exact baseline, zero delta; tsc/build clean; all 4 prerendered routes byte-equivalent to v6; **`npm audit`: 2 moderates → 0** (GHSA-wrjc-x8rr-h8h6, GHSA-337j-9hxr-rhxg cleared).

**This completes the estate dependency sweep** — all 7 repos current, every repo audit-clean.
